### PR TITLE
Added Like Song for Apple Music

### DIFF
--- a/Jukebox/Models/Track.swift
+++ b/Jukebox/Models/Track.swift
@@ -12,5 +12,6 @@ struct Track {
     var title = ""
     var artist = ""
     var album = ""
+    var loved = false
     var albumArt = NSImage()
 }

--- a/Jukebox/ViewModels/ContentViewModel.swift
+++ b/Jukebox/ViewModels/ContentViewModel.swift
@@ -34,6 +34,7 @@ class ContentViewModel: ObservableObject {
     // Track
     @Published var track = Track()
     @Published var isPlaying = false
+    @Published var isLoved = false
     
     // Seeker
     @Published var timer = Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()
@@ -165,7 +166,7 @@ class ContentViewModel: ObservableObject {
             self.track.title = appleMusicApp?.currentTrack?.name ?? "Unknown Title"
             self.track.artist = appleMusicApp?.currentTrack?.artist ?? "Unknown Artist"
             self.track.album = appleMusicApp?.currentTrack?.album ?? "Unknown Album"
-            
+            self.isLoved = appleMusicApp?.currentTrack?.loved ?? false
             // Might have to change this later...
             var count = 0
             var waitForData: (() -> Void)!
@@ -225,6 +226,18 @@ class ContentViewModel: ObservableObject {
             spotifyApp?.nextTrack?()
         case .appleMusic:
             appleMusicApp?.nextTrack?()
+        }
+    }
+    
+    func toggleLoveTrack() {
+        switch connectedApp {
+        case .appleMusic:
+            if let isLovedTrack = appleMusicApp?.currentTrack?.loved {
+                appleMusicApp?.currentTrack?.setLoved?(!isLovedTrack)
+                self.isLoved = !isLovedTrack
+            }
+        case .spotify:
+            print("Not supported")
         }
     }
     

--- a/Jukebox/Views/ContentView.swift
+++ b/Jukebox/Views/ContentView.swift
@@ -11,6 +11,7 @@ struct ContentView: View {
     
     // User Defaults
     @AppStorage("visualizerStyle") private var visualizerStyle: VisualizerStyle = .albumArt
+    @AppStorage("connectedApp") private var connectedApp: ConnectedApps = .spotify
     
     // View Model
     @ObservedObject var contentViewVM: ContentViewModel
@@ -65,6 +66,15 @@ struct ContentView: View {
                             
                             // Playback Buttons
                             HStack(spacing: 6) {
+                                if case connectedApp = ConnectedApps.appleMusic {
+                                    Button {
+                                        contentViewVM.toggleLoveTrack()
+                                    } label: {
+                                        Image(systemName: contentViewVM.isLoved ? "heart.fill" : "heart")
+                                            .font(.system(size: 14))
+                                            .foregroundColor(.primary.opacity(primaryOpacity))
+                                    }.pressButtonStyle()
+                                }
                                 Button {
                                     contentViewVM.previousTrack()
                                 } label: {


### PR DESCRIPTION
Hi there, I added the capability to like a song right from the Song Control Popup

Unfortunately, this currently only works for Apple Music

Active:
<img width="275" alt="Screen Shot 2022-02-01 at 19 41 48" src="https://user-images.githubusercontent.com/20226905/152030636-f3afcc12-b514-440f-acea-ee4645ea8827.png">

Non-Active:
<img width="270" alt="image" src="https://user-images.githubusercontent.com/20226905/152030701-fb235865-de24-4223-b21a-547b8124e5b6.png">
